### PR TITLE
fix: allocating vectors with pre-defined size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 crate-type = ["cdylib"]
 
 [dependencies]
-itertools = { version = "0.10.3" }
+itertools = { version = "0.13.0" }
 redis-module = { version = "1.0.1", features = ["experimental-api"] }
 
 [features]

--- a/src/commands/pubsub.rs
+++ b/src/commands/pubsub.rs
@@ -13,7 +13,7 @@ pub fn mpublish(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let mut mutable_args = args.into_iter().skip(1).rev();
     let message = mutable_args.next_arg()?;
 
-    let mut response: Vec<RedisValue> = Vec::new();
+    let mut response: Vec<RedisValue> = Vec::with_capacity(mutable_args.len());
 
     for channel in mutable_args {
         let result = call(ctx, "publish", &[&channel, &message]);

--- a/src/commands/streams.rs
+++ b/src/commands/streams.rs
@@ -12,7 +12,7 @@ pub fn xmrevrange(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let keyword = mutable_args.next_string()?;
     let count = mutable_args.next_string()?;
 
-    let mut response: Vec<RedisValue> = Vec::new();
+    let mut response: Vec<RedisValue> = Vec::with_capacity(mutable_args.len());
 
     for arg in mutable_args {
         let key = RedisString::to_string_lossy(&arg);


### PR DESCRIPTION
Avoiding re-allocating vectors when we know what size it'll be.