### PR TITLE
feat: using split_last instead of access args via slice

### DIFF
--- a/src/commands/pubsub.rs
+++ b/src/commands/pubsub.rs
@@ -10,9 +10,9 @@ pub fn mpublish(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
         return Err(RedisError::WrongArity);
     }
 
-    let args_len = number_of_args - 1;
-    let message = &args[args_len];
-    let channels = &args[1..args_len];
+    let Some((message, channels)) = args[1..].split_last() else {
+        return Err(RedisError::WrongArity);
+    };
 
     let mut response: Vec<RedisValue> = Vec::with_capacity(channels.len());
 


### PR DESCRIPTION
Avoids doing 2 bounds checks.
Cleaner error handling.

SD-7448